### PR TITLE
Tab key now selects item

### DIFF
--- a/inputDropdown.js
+++ b/inputDropdown.js
@@ -205,6 +205,11 @@ angular.module('inputDropdown', []).directive('inputDropdown', [function() {
               scope.$apply(selectActiveItem);
             }
             break;
+          case 9: // tab
+            if (scope.dropdownVisible && scope.dropdownItems && scope.dropdownItems.length > 0 && scope.activeItemIndex !== -1) {              
+              scope.$apply(selectActiveItem);
+            }
+            break;
         }
       });
     }


### PR DESCRIPTION
If the tab key is pressed while the dropdown list is visible,
it will select the active item.  preventDefault is not called,
so focus will to next tab index, which is the expected behavior,
in my opinion.
